### PR TITLE
Split Fetcher into variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ git repos or specialized storage systems.
 If repositories don't wish to implement or expose all capabilities they can
 implement only the `Fetcher` the `Storer` interfaces.
 
+### Specialized Vaariants
+
+As we identify useful capabilities, more fetcher and storer types will be defined.
+This allows implementations,such as the
+[Carabiner collector](https://github.com/carabiner-dev/collector), to leverage
+optimized capabilities from the repository implementaion backends.
+
+At present we have defined the `FetcherBySubject`, `FetcherByPredicateType` and
+`FetcherByPredicateTypeAndSubject` specialized fetchers.
+
 ## Attestation Queries
 
 Once a repository is queried and returns a set of attestations, AMPEL can use

--- a/repository.go
+++ b/repository.go
@@ -13,19 +13,35 @@ var (
 	ErrStorerMethodNotImplemented  = errors.New("storing method not implemented")
 )
 
-// Repository is an abstraction that stores attestations, serves them or both.
+// Repository is an abstraction of a system that can store attestations, serve
+// them or both.
 // Repositories can express their capabilities by implementing the Storer and/or
-// Fetcher interfaces.
+// Fetcher interfaces and their specialized variants.
 type Repository interface{} //nolint:iface // To be implemented
 
 // AttestationFetcher is the the trait that repositories that can fetch
 // attestations must implement
 type Fetcher interface {
 	Fetch(context.Context, FetchOptions) ([]Envelope, error)
+}
+
+// FetcherBySubject is a fetcher that can filter natively by subject hashes.
+type FetcherBySubject interface {
 	FetchBySubject(context.Context, FetchOptions, []Subject) ([]Envelope, error)
+}
+
+// FetcherByPredicateType is a fetcher that can filter natively by predictae types.
+type FetcherByPredicateType interface {
 	FetchByPredicateType(context.Context, FetchOptions, []PredicateType) ([]Envelope, error)
 }
 
+// FetcherByPredicateTypeAndSubject is a fetcher that can filter natively by
+// predictae types and subject.
+type FetcherByPredicateTypeAndSubject interface {
+	FetchByPredicateTypeAndSubject(context.Context, FetchOptions, []PredicateType, []Subject) ([]Envelope, error)
+}
+
+// Storer is a repository that can store attestations
 type Storer interface {
 	Store(context.Context, StoreOptions, []Envelope) error
 }


### PR DESCRIPTION
This commit splits the attestation fetcher interface into specialized variants: FetcherBySubject and FetcherByPredicateType.

This will allow implementations to optimize fetching by leveraging capabilities of the implementation backends.