### PR TITLE
Envelope: Support verification material

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -3,6 +3,20 @@
 
 package attestation
 
+// EnvelopeVerificationOptions are values used to verify signed envelopes that
+// may be useful to all envelop implementations.
+type EnvelopeVerificationOptions struct {
+	// AllowUnsigned causes the verification to fail if an envelope is not signed.
+	AllowUnsigned bool
+}
+
+// EnvVerOptsConvertable is an interface that any verification material that
+// can be converted to an EnvelopeVerificationOptions can implement to get
+// data from the verifier.
+type EnvVerOptsConvertable interface {
+	ToEnvelopeVerificationOptions() EnvelopeVerificationOptions
+}
+
 // Envelope is a construct that wraps a statement, its signatures and all the
 // verification material. The goal of this abstraction is to get a single
 // interface to verify statements, even when all the bits amy be in separate
@@ -13,5 +27,5 @@ type Envelope interface {
 	GetSignatures() []Signature
 	GetCertificate() Certificate
 	GetVerification() Verification
-	Verify() error
+	Verify(...any) error
 }


### PR DESCRIPTION
This commit introduces a breaking change to the envelope interface. From now on, the Verify() method can take values to support passing implementation-specific verification material.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>