### PR TITLE
Update CI to latest pattern

### DIFF
--- a/.github/workflows/go-build-and-test.yaml
+++ b/.github/workflows/go-build-and-test.yaml
@@ -9,19 +9,42 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  test:
+  resolve-versions:
     runs-on: ubuntu-latest
+    outputs:
+      go-versions: ${{ steps.matrix.outputs.go-versions }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-          persist-credentials: false
+        persist-credentials: false
 
-    - name: Set up Go
+    - name: Resolve Go versions
+      id: go-versions
+      uses: carabiner-dev/actions/go/versions@515c0fe38ee52c692f976c9f761b8acf6fb31cac # v1.1.3
+
+    - name: Build version matrix
+      id: matrix
+      run: |
+        echo "go-versions=[\"${{ steps.go-versions.outputs.GO_VERSION_STABLE }}\",\"${{ steps.go-versions.outputs.GO_VERSION_PREVIOUS }}\"]" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ${{ fromJSON(needs.resolve-versions.outputs.go-versions) }}
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: '1.24'
-        check-latest: true
-        cache: true
+        go-version: ${{ matrix.go-version }}
+        cache: false
 
     - name: Test
       run: |

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,13 +21,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve Go versions
+        id: go-versions
+        uses: carabiner-dev/actions/go/versions@515c0fe38ee52c692f976c9f761b8acf6fb31cac # v1.1.3
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.24'
-          check-latest: true
+          go-version: ${{ steps.go-versions.outputs.GO_VERSION_STABLE }}
           cache: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.1
+          version: v2.11

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
-
 # SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
----
+
 name: Release
 
 on:
@@ -9,30 +8,33 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write # needed to write releases 
+      contents: write
+      id-token: write
+      attestations: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set tag output
-        id: tag
-        run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v3
-        with:
-          go-version-file: go.mod
-          cache: false  
-          check-latest: true
-  
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Set tag output
+        id: tag
+        run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
 
       - name: Install bom
         uses: kubernetes-sigs/release-actions/setup-bom@ab33480f30919958240822cfc29af8d9903f313b # v0.4.1


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve Go version management, enhance permissions for releases, and update tooling versions. The main goals are to automate Go version selection, ensure workflows use the latest stable and previous Go versions, and align permissions and tool versions with best practices.

**Go version management and workflow improvements:**

* Added a `resolve-versions` job to `.github/workflows/go-build-and-test.yaml` to dynamically determine and set up a matrix for the latest stable and previous Go versions, ensuring tests run against both. The Go cache was also disabled for these jobs to improve reliability.
* Updated `.github/workflows/golangci-lint.yaml` to resolve and use the latest stable Go version dynamically for linting, and upgraded `golangci-lint` to version `v2.11` for improved linting features.

**Release workflow enhancements:**

* Improved `.github/workflows/release.yaml` by refining permissions (added `id-token` and `attestations`), updating the `actions/setup-go` version, and making the code checkout step more robust by specifying `fetch-depth` and disabling credential persistence.